### PR TITLE
Fix navbar notification alignment - bell and count on same line

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -62,7 +62,7 @@ export function Navbar() {
                 <div className="hidden md:flex md:items-center md:space-x-4">
                   <Link
                     href="/notifications"
-                    className="relative p-2 text-gray-600 hover:text-gray-900"
+                    className="relative inline-flex items-center p-2 text-gray-600 hover:text-gray-900"
                   >
                     <Bell className="h-5 w-5" />
                     {unreadCount && unreadCount > 0 && (


### PR DESCRIPTION
## Description
Fixes #8

This PR fixes the navbar notifications section where the bell icon and notification count were displaying on separate lines.

## Changes
- Added `inline-flex` and `items-center` classes to the notification Link component
- Ensures the bell icon and notification badge are horizontally aligned in a single line

## Testing
- Verified the notification bell and count display correctly in the navbar
- The badge is positioned in the top-right corner of the bell icon as expected

## Screenshots
The notification bell and count now display on the same line with proper alignment.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed notifications icon and badge alignment in the navigation bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->