### PR TITLE
feat: Add leaderboard snippets to hero section with top contributors and AI agents

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,14 @@
+"use client";
+
 import Link from "next/link";
-import { Code2, Trophy, GitPullRequest, DollarSign, ArrowRight } from "lucide-react";
+import { Code2, Trophy, GitPullRequest, DollarSign, ArrowRight, TrendingUp, Medal, Award } from "lucide-react";
 import { Navbar } from "@/components/Navbar";
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
 
 export default function Home() {
+  const topUsers = useQuery(api.users.getLeaderboard, { limit: 4 });
+  const agentStats = useQuery(api.codingAgents.getCodingAgentStats);
   return (
     <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white">
       <Navbar />
@@ -31,6 +37,184 @@ export default function Home() {
             >
               Post an Issue
             </Link>
+          </div>
+        </div>
+
+        {/* Leaderboard Snippets */}
+        <div className="mt-16 grid lg:grid-cols-2 gap-8">
+          {/* Top Contributors */}
+          <div className="h-[500px]">
+            <div className="bg-white rounded-xl shadow-lg border border-gray-200 overflow-hidden h-full flex flex-col">
+              <div className="bg-gradient-to-r from-yellow-50 to-orange-50 px-6 py-4 border-b border-gray-200">
+                <div className="flex items-center justify-center space-x-2">
+                  <Trophy className="h-6 w-6 text-yellow-600" />
+                  <h2 className="text-xl font-bold text-gray-900">Top Contributors</h2>
+                </div>
+              </div>
+
+              {!topUsers ? (
+                <div className="text-center py-8 flex-1">
+                  <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto"></div>
+                </div>
+              ) : topUsers.length === 0 ? (
+                <div className="p-8 text-center flex-1">
+                  <p className="text-gray-600">No contributors yet. Be the first to earn bounties!</p>
+                </div>
+              ) : (
+                <div className="divide-y divide-gray-200 flex-1 overflow-auto">
+                  {topUsers.map((user, index) => (
+                    <div
+                      key={user._id}
+                      className={`p-4 flex items-center space-x-3 min-h-[88px] ${
+                        index === 0 ? "bg-gradient-to-r from-yellow-50 to-white" : ""
+                      }`}
+                    >
+                      {/* Rank */}
+                      <div className="flex-shrink-0 w-8 text-center">
+                        {index === 0 && (
+                          <Trophy className="h-5 w-5 text-yellow-500 mx-auto" />
+                        )}
+                        {index === 1 && (
+                          <Medal className="h-5 w-5 text-gray-400 mx-auto" />
+                        )}
+                        {index === 2 && (
+                          <Award className="h-5 w-5 text-orange-600 mx-auto" />
+                        )}
+                        {index > 2 && (
+                          <span className="text-sm font-bold text-gray-400">
+                            #{index + 1}
+                          </span>
+                        )}
+                      </div>
+
+                      {/* Profile Image */}
+                      {user.image ? (
+                        <img
+                          src={user.image}
+                          alt={user.name || "User"}
+                          className="h-10 w-10 rounded-full flex-shrink-0"
+                        />
+                      ) : (
+                        <div className="h-10 w-10 rounded-full bg-blue-600 flex items-center justify-center text-white font-bold flex-shrink-0">
+                          {(user.name || user.githubUsername || "?")[0].toUpperCase()}
+                        </div>
+                      )}
+
+                      {/* User Info */}
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-semibold text-gray-900 truncate">
+                          {user.name || user.githubUsername}
+                        </p>
+                        <p className="text-xs text-gray-500 truncate">
+                          @{user.githubUsername}
+                        </p>
+                      </div>
+
+                      {/* Stats */}
+                      <div className="text-right flex-shrink-0">
+                        <p className="text-lg font-bold text-yellow-600">
+                          {user.totalEarnings}
+                        </p>
+                        <p className="text-xs text-gray-600">points</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              <div className="px-6 py-4 bg-gray-50 border-t border-gray-200 mt-auto">
+                <Link
+                  href="/leaderboard"
+                  className="block w-full text-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors"
+                >
+                  View the Full Leaderboard
+                </Link>
+              </div>
+            </div>
+          </div>
+
+          {/* Top AI Agents */}
+          <div className="h-[500px]">
+            <div className="bg-white rounded-xl shadow-lg border border-gray-200 overflow-hidden h-full flex flex-col">
+              <div className="bg-gradient-to-r from-blue-50 to-indigo-50 px-6 py-4 border-b border-gray-200">
+                <div className="flex items-center justify-center space-x-2">
+                  <TrendingUp className="h-6 w-6 text-blue-600" />
+                  <h2 className="text-xl font-bold text-gray-900">Top AI Agents</h2>
+                </div>
+              </div>
+
+              {!agentStats ? (
+                <div className="text-center py-8 flex-1">
+                  <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto"></div>
+                </div>
+              ) : agentStats.length === 0 ? (
+                <div className="p-8 text-center flex-1">
+                  <p className="text-gray-600">No agent data yet. Start submitting PRs!</p>
+                </div>
+              ) : (
+                <div className="divide-y divide-gray-200 flex-1 overflow-auto">
+                  {agentStats.slice(0, 3).map((agentStat, index) => (
+                    <div key={agentStat.agent._id} className="p-4 flex flex-col justify-center min-h-[88px]">
+                      <div className="flex items-center justify-between mb-2">
+                        <div className="flex-1">
+                          <div className="flex items-center space-x-2">
+                            <span className="text-sm font-bold text-gray-400">
+                              #{index + 1}
+                            </span>
+                            <h3 className="text-sm font-semibold text-gray-900">
+                              {agentStat.agent.name}
+                            </h3>
+                          </div>
+                        </div>
+                        <div className="ml-4 text-right flex-shrink-0">
+                          <p className="text-lg font-bold text-green-600">
+                            {agentStat.stats.successRate}%
+                          </p>
+                          <p className="text-xs text-gray-600">success</p>
+                        </div>
+                      </div>
+
+                      {/* Stats Grid */}
+                      <div className="grid grid-cols-4 gap-2">
+                        <div className="text-center">
+                          <p className="text-sm font-bold text-gray-900">
+                            {agentStat.stats.totalPRs}
+                          </p>
+                          <p className="text-xs text-gray-600">PRs</p>
+                        </div>
+                        <div className="text-center">
+                          <p className="text-sm font-bold text-green-600">
+                            {agentStat.stats.mergedPRs}
+                          </p>
+                          <p className="text-xs text-gray-600">Merged</p>
+                        </div>
+                        <div className="text-center">
+                          <p className="text-sm font-bold text-red-600">
+                            {agentStat.stats.rejectedPRs}
+                          </p>
+                          <p className="text-xs text-gray-600">Rejected</p>
+                        </div>
+                        <div className="text-center">
+                          <p className="text-sm font-bold text-yellow-600">
+                            {agentStat.stats.totalBountiesWon}
+                          </p>
+                          <p className="text-xs text-gray-600">Points</p>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              <div className="px-6 py-4 bg-gray-50 border-t border-gray-200 mt-auto">
+                <Link
+                  href="/leaderboard"
+                  className="block w-full text-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors"
+                >
+                  View the Full Leaderboard
+                </Link>
+              </div>
+            </div>
           </div>
         </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -106,14 +106,14 @@ export default function Home() {
                           {user.name || user.githubUsername}
                         </p>
                         <p className="text-xs text-gray-500 truncate">
-                          @{user.githubUsername}
+                          @{user.githubUsername ?? 'unknown'}
                         </p>
                       </div>
 
                       {/* Stats */}
                       <div className="text-right flex-shrink-0">
                         <p className="text-lg font-bold text-yellow-600">
-                          {user.totalEarnings}
+                          {user.totalEarnings ?? 0}
                         </p>
                         <p className="text-xs text-gray-600">points</p>
                       </div>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -74,7 +74,7 @@ export function Navbar() {
 
                   <div className="flex items-center space-x-2">
                     <span className="text-sm font-medium text-gray-700">
-                      {currentUser.totalEarnings} pts
+                      {currentUser.totalEarnings ?? 0} pts
                     </span>
                   </div>
 

--- a/convex/dev.ts
+++ b/convex/dev.ts
@@ -1,4 +1,4 @@
-import { mutation } from "./_generated/server";
+import { mutation, internalMutation } from "./_generated/server";
 import { v } from "convex/values";
 
 /**
@@ -152,7 +152,7 @@ export const approvePullRequestDev = mutation({
   },
 });
 
-export const insertTestUser = mutation({
+export const insertTestUser = internalMutation({
   args: {
     githubId: v.string(),
     githubUsername: v.string(),
@@ -177,7 +177,7 @@ export const insertTestUser = mutation({
   },
 });
 
-export const updateUserEarnings = mutation({
+export const updateUserEarnings = internalMutation({
   args: {
     userId: v.id("users"),
     totalEarnings: v.number(),

--- a/convex/dev.ts
+++ b/convex/dev.ts
@@ -151,3 +151,44 @@ export const approvePullRequestDev = mutation({
     return args.prId;
   },
 });
+
+export const insertTestUser = mutation({
+  args: {
+    githubId: v.string(),
+    githubUsername: v.string(),
+    name: v.string(),
+    image: v.optional(v.string()),
+    totalEarnings: v.number(),
+    totalPRsSubmitted: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await ctx.db.insert("users", {
+      githubId: args.githubId,
+      githubUsername: args.githubUsername,
+      name: args.name,
+      image: args.image,
+      totalEarnings: args.totalEarnings,
+      totalBountiesPosted: 0,
+      totalPRsSubmitted: args.totalPRsSubmitted,
+      createdAt: Date.now(),
+    });
+
+    return userId;
+  },
+});
+
+export const updateUserEarnings = mutation({
+  args: {
+    userId: v.id("users"),
+    totalEarnings: v.number(),
+    totalPRsSubmitted: v.number(),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.userId, {
+      totalEarnings: args.totalEarnings,
+      totalPRsSubmitted: args.totalPRsSubmitted,
+    });
+
+    return args.userId;
+  },
+});


### PR DESCRIPTION
## Description

This PR implements the feature requested in issue #10 to add leaderboard snippets to the hero section of the homepage.

## Changes Made

### Frontend (Next.js)
- **Converted homepage to client component** - Added `"use client"` directive to enable Convex queries
- **Added Top Contributors snippet** showing:
  - Top 4 contributors with profile images
  - Trophy icons for 1st (gold), 2nd (silver), 3rd (bronze) place
  - Rank numbers for 4th place
  - User names, GitHub usernames, and total points earned
  - Profile images with fallback to colored circles with initials
- **Added Top AI Agents snippet** showing:
  - Top 3 AI coding agents
  - Success rate prominently displayed
  - Detailed stats grid (Total PRs, Merged, Rejected, Points)
  - Rank numbers for each agent
- **Implemented responsive layout**:
  - Side-by-side display on large screens using `lg:grid-cols-2`
  - Stacked layout on mobile devices
  - Fixed 500px height for both containers
  - Flexbox layout to pin "View Full Leaderboard" buttons to bottom
  - No white space at bottom of containers
- **Added "View the Full Leaderboard" buttons** linking to `/leaderboard` page
- **Implemented loading states** with spinners while data is being fetched
- **Added empty states** with encouraging messages when no data exists

### Backend (Convex)
- **Added dev mutations** in `convex/dev.ts`:
  - `insertTestUser` - Create test users with custom earnings and PR counts
  - `updateUserEarnings` - Update user stats for testing purposes
  - These are development-only helpers for manual testing

## Features

✅ Displays top 4 contributors sorted by total earnings
✅ Displays top 3 AI agents sorted by performance
✅ Real-time data from Convex queries
✅ Responsive design matching existing UI
✅ Profile images with fallback initials
✅ Trophy icons for top 3 contributors
✅ Detailed agent statistics
✅ Loading and empty states
✅ Fixed height containers (500px) with no white space
✅ "View Full Leaderboard" buttons pinned to bottom

## Visual Design

**Top Contributors:**
- Yellow/orange gradient header with Trophy icon
- Gold, silver, bronze trophy icons for top 3
- Profile images (40x40px, rounded)
- Special highlighting for #1 contributor
- Points displayed prominently

**Top AI Agents:**
- Blue/indigo gradient header with TrendingUp icon
- Success rate prominently displayed
- 4-column stats grid for detailed metrics
- Compact design to match contributor rows

## Testing

- ✅ Development server runs without errors
- ✅ Components compile successfully
- ✅ Queries return properly formatted data
- ✅ Responsive layout works on different screen sizes
- ✅ Loading states display correctly
- ✅ Empty states display correctly
- ✅ Buttons link to correct pages
- ✅ No white space at bottom of containers

Fixes #10

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Top Contributors and Top AI Agents leaderboard snippets added to the homepage, with full-width panels and links to full leaderboards.
  * Leaderboards show ranked visuals, profile fallbacks, agent metrics (PRs, merged/rejected, points, success rate).

* **Bug Fixes**
  * Earnings display now reliably shows 0 when a user's earnings are missing.

* **UX**
  * Added loading spinners, empty-state messages, and consistent skeleton UI for leaderboard panels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->